### PR TITLE
Typo in sounds.json

### DIFF
--- a/assets/pudge/sounds.json
+++ b/assets/pudge/sounds.json
@@ -500,13 +500,13 @@
 			"pudge:announcer/redmage/team_killer"
 		]
 	},
-	"game.music.victory.realms": {
+	"game.music.victory_realms": {
 		"sounds": [
 			"pudge:music/victory_realms"
 		],
 		"stream": true
 	},
-	"game.music.defeat.realms": {
+	"game.music.defeat_realms": {
 		"sounds": [
 			"pudge:music/defeat_realms"
 		],


### PR DESCRIPTION
Fixed a typo that prevents realms cutscene music from playing when using the full pack (not present in basic pack)